### PR TITLE
Adds multi line visual mode select and run

### DIFF
--- a/autoload/seeing_is_believing.vim
+++ b/autoload/seeing_is_believing.vim
@@ -36,3 +36,49 @@ function! seeing_is_believing#toggle_mark(mode) range "{{{
   set nolazyredraw
   redraw
 endfun "}}}
+
+function! seeing_is_believing#visual() range "{{{
+  let [lnum1, col1] = getpos("'<")[1:2]
+  let [lnum2, col2] = getpos("'>")[1:2]
+  let lines = getline(lnum1, lnum2)
+
+  let max = GetMaxLength(lines)
+  let annotated_lines = AnnotateLines(lines, max)
+
+  let @x = join(annotated_lines, "\n")
+  normal! gv
+  normal! "xP
+  call seeing_is_believing#run('n')
+endfun "}}}
+
+function! AnnotateLines(lines, max) "{{{
+  let i = 0
+
+  while i < len(a:lines)
+    let length = len(a:lines[i])
+    let spaces = (a:max - length) + 1
+    if length > 0
+      let a:lines[i] .= repeat(" ", spaces) . " # => "
+    endif
+    let i += 1
+  endwhile
+
+  return a:lines
+endfun "}}}
+
+function! GetMaxLength(lines) "{{{
+  let i = 0
+  let max = 0
+
+  while i < len(a:lines)
+    let length = len(a:lines[i])
+    if length > max
+      let max = length
+    endif
+    let i += 1
+  endwhile
+
+  return max
+endfun "}}}
+
+

--- a/plugin/seeing_is_believing.vim
+++ b/plugin/seeing_is_believing.vim
@@ -20,7 +20,7 @@ set cpo&vim
 " KEYMAP: {{{
 "=================================================================
 nnoremap <silent> <Plug>(seeing-is-believing-run)        :call seeing_is_believing#run('n')<CR>
-vnoremap <silent> <Plug>(seeing-is-believing-run)        :call seeing_is_believing#run('v')<CR>
+vnoremap <silent> <Plug>(seeing-is-believing-run-visual)        :call seeing_is_believing#visual()<CR>
 inoremap <silent> <Plug>(seeing-is-believing-run)   <C-o>:call seeing_is_believing#run('i')<CR>
 
 nnoremap <silent> <Plug>(seeing-is-believing-mark)      :call seeing_is_believing#toggle_mark('n')<CR>


### PR DESCRIPTION
Basically, no more need to mark then run. Just do a visual selection then run. 

Also added indentation so that the output looks like this

```
[*1..5]            # => [1, 2, 3, 4, 5]
  .select &:even?  # => [2, 4]
```
